### PR TITLE
Fixes #1

### DIFF
--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -15,10 +15,10 @@ function interpolate(rules, width) {
 
     const bounds = sortedBounds(rules[key]);
     // Use the smallest breakpoint value if below
-    if (width < bounds[0]) return { [key]: rules[key][bounds[0]] };
+    if (width <= bounds[0]) return { [key]: rules[key][bounds[0]] };
 
     // Use the largest breakpoint value if below
-    if (width > bounds[bounds.length - 1]) {
+    if (width >= bounds[bounds.length - 1]) {
       return { [key]: rules[key][bounds[bounds.length - 1]] };
     }
 

--- a/test/interpolate.test.js
+++ b/test/interpolate.test.js
@@ -17,6 +17,7 @@ test('interpolate generates functions from tweenable styles', (assert) => {
   assert.deepEqual(style(0), { color: '#fff', lineHeight: 1 });
   assert.deepEqual(style(200), { color: '#fff', lineHeight: 1.5 });
   assert.deepEqual(style(400), { color: '#fff', lineHeight: 7 });
+  assert.deepEqual(style(500), { color: '#fff', lineHeight: 12 });
   assert.deepEqual(style(600), { color: '#fff', lineHeight: 12 });
   assert.end();
 });


### PR DESCRIPTION
Ensure interpolate returns the correct result when passed the highest
breakpoint size.