### PR TITLE
Fix calc interpolation logic

### DIFF
--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -81,7 +81,8 @@ function linearlyInterpolate(a, b, x) {
 }
 
 function interpolateWithCalc(a, b, x) {
-  return `calc(${a} + (${parseFloat(b) * x}${units(b)}))`;
+  return `calc(${parseFloat(a) * (1 - x)}${units(a)} + ` +
+         `(${parseFloat(b) * x}${units(b)}))`;
 }
 
 function isNumeric(s) { return !isNaN(parseFloat(s)) && isFinite(s); }

--- a/test/interpolate.test.js
+++ b/test/interpolate.test.js
@@ -133,9 +133,9 @@ test('interpolate uses calc to resolve unit mismatches', (assert) => {
     fontSize: { 0: '15vh', 2: '-20vw' },
   });
   assert.deepEqual(style(1), {
-    margin: 'calc(5px + (5em))',
-    padding: 'calc(-12% + (2px))',
-    fontSize: 'calc(15vh + (-10vw))',
+    margin: 'calc(2.5px + (5em))',
+    padding: 'calc(-6% + (2px))',
+    fontSize: 'calc(7.5vh + (-10vw))',
   });
   assert.end();
 });


### PR DESCRIPTION
Was incorrectly assuming 100% of the lower bound value, rather than
transitioning between the a and b values.