### PR TITLE
Support single-breakpoint property definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Now your `App` component will have a width property that matches the
 There are a few cases where the Superficial library makes some assumptions
 about what you intend, where otherwise things might be ambiguous. In the
 examples below, we show what the resulting value is exactly between two
-breakpoints:
+breakpoints. Note that the `between` function does not exist; it is provided
+solely to illustrate the library's behavior in certain cases.
 
 ### CSS shorthand expressions
 ```js
@@ -129,7 +130,20 @@ simply pull out the values from each breakpoint. The format, however, needs to
 be the consistent for a given CSS property. Mixing different types of shortand
 (`margin: { 100: '15px auto', 400: '20px 5px 10px' }`) is not supported.
 
-### Mixing Unit and Unitless Values
+### Single-Breakpoint expressions
+```js
+height: { 500: '100px', 0: 0 }; // Standard definition
+height: { 500: '100px' };       // Syntactic shortcut
+```
+
+Frequently, it may be valuable to express a single breakpoint, assuming a
+linear responsiveness for values below. If a property is specified for a given
+width, it can be assumed that it should scale proportionally below that width.
+If a single breakpoint is provided, Superficial will treat the expression as
+though there were an additional breakpoint at `0` width for which the property
+value is 0.
+
+### Mixing unit and unitless values
 ```js
 between(0, '15px') // '7.5px'
 between(5, '20em') // '12.5em'

--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -19,19 +19,25 @@ function interpolate(rules, width) {
     if (typeof rules[key] !== 'object') return null;
     const bounds = sortedBounds(rules[key]);
 
+    let values = rules[key];
+    if (bounds.length === 1) {
+      bounds.unshift(0);
+      values = Object.assign({ 0: 0 }, values);
+    }
+
     // Use the smallest breakpoint value if below
-    if (width <= bounds[0]) return { [key]: rules[key][bounds[0]] };
+    if (width <= bounds[0]) return { [key]: values[bounds[0]] };
 
     // Use the largest breakpoint value if above
     const last = bounds[bounds.length - 1];
-    if (width >= last) return { [key]: rules[key][last] };
+    if (width >= last) return { [key]: values[last] };
 
     // Interpolate values between the nearest neighbors
     const upperBound = bounds.find(b => b > width);
     const lowerBound = bounds[bounds.indexOf(upperBound) - 1];
     return { [key]: interpolateValues(
-      rules[key][lowerBound],
-      rules[key][upperBound],
+      values[lowerBound],
+      values[upperBound],
       (width - lowerBound) / (upperBound - lowerBound),
     ) };
   }));

--- a/src/wrapComponent.js
+++ b/src/wrapComponent.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import wrapRendered from './wrapRendered';
 

--- a/test/interpolate.test.js
+++ b/test/interpolate.test.js
@@ -79,6 +79,16 @@ test('interpolate allows keyword values in CSS shorthand', (assert) => {
   assert.end();
 });
 
+test('interpolate assumes 0: 0 values for single-breakpoint properties', (assert) => {
+  const style = interpolate({ 2: { margin: '2px' } });
+  assert.equal(style(2).margin, '2px');
+  assert.equal(style(0).margin, 0);
+  assert.equal(style(-5).margin, 0);
+  assert.equal(style(100).margin, '2px');
+  assert.equal(style(1).margin, '1px');
+  assert.end();
+});
+
 test('interpolate allows selective properties in breakpoints', (assert) => {
   const style = interpolate({
     0: { margin: '0px' },

--- a/test/interpolate.test.js
+++ b/test/interpolate.test.js
@@ -79,7 +79,7 @@ test('interpolate allows keyword values in CSS shorthand', (assert) => {
   assert.end();
 });
 
-test('interpolate assumes 0: 0 values for single-breakpoint properties', (assert) => {
+test('interpolate assumes a 0 for single-breakpoint properties', (assert) => {
   const style = interpolate({ 2: { margin: '2px' } });
   assert.equal(style(2).margin, '2px');
   assert.equal(style(0).margin, 0);


### PR DESCRIPTION
Fixes #20 - Assumes a `0: 0` breakpoint for properties that only contain a
single breakpoint